### PR TITLE
Get robot_pose from tf by looking up map -> point cloud frame id at header stamp

### DIFF
--- a/src/surface_based_object_learning/object_learning_core.py
+++ b/src/surface_based_object_learning/object_learning_core.py
@@ -371,7 +371,7 @@ class LearningCore:
                 self.cur_observation_data['robot_pose'] = rospy.wait_for_message("/robot_pose", geometry_msgs.msg.Pose, timeout=10.0)
 
                 try:
-                    self.tf_listener.waitForTransform(scene.header.frame_id, '/map', scene.header.stamp, rospy.Duration(0.1))¶
+                    self.tf_listener.waitForTransform('/map', scene.header.frame_id, scene.header.stamp, rospy.Duration(0.1))¶
                     (trans, rot) = self.tf_listener.lookupTransform(scene.header.frame_id, '/map', scene.header.stamp)
                     pose_msg = Pose()
                     pose_msg.position.x = trans[0]

--- a/src/surface_based_object_learning/object_learning_core.py
+++ b/src/surface_based_object_learning/object_learning_core.py
@@ -380,8 +380,8 @@ class LearningCore:
                     pose_msg.orientation.x = rot[0]
                     pose_msg.orientation.y = rot[1]
                     pose_msg.orientation.z = rot[2]
-                    pose_msg.orientation.z = rot[3]
-                    robot_pose = pose_msg
+                    pose_msg.orientation.w = rot[3]
+                    self.cur_observation_data['robot_pose'] = pose_msg
                 except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
                     rospy.logerr("Could not get TF transform from /map to %s" % scene.header.frame_id)
 

--- a/src/surface_based_object_learning/object_learning_core.py
+++ b/src/surface_based_object_learning/object_learning_core.py
@@ -371,7 +371,7 @@ class LearningCore:
                 self.cur_observation_data['robot_pose'] = rospy.wait_for_message("/robot_pose", geometry_msgs.msg.Pose, timeout=10.0)
 
                 try:
-                    self.tf_listener.waitForTransform('/map', scene.header.frame_id, scene.header.stamp, rospy.Duration(0.1))¶
+                    self.tf_listener.waitForTransform('/map', scene.header.frame_id, scene.header.stamp, rospy.Duration(0.1))
                     (trans, rot) = self.tf_listener.lookupTransform(scene.header.frame_id, '/map', scene.header.stamp)
                     pose_msg = Pose()
                     pose_msg.position.x = trans[0]


### PR DESCRIPTION
@jayyoung This needs testing but I mainly wanted to know if you have any objections against doing this? I recall you saying that you do not use robot pose at all? In that case this seems like the easy solution to our problem, it avoids changing message definitions etc.